### PR TITLE
Replace deprecated download host with official Cursor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ rm -rf ~/.config/Cursor ~/.cache/Cursor
 /opt/cursor.appimage --no-sandbox
 ```
 
-### **💡 "`jq: command not found` (or similar) during install?**
+### **💡 `jq: command not found` (or similar) during install?**
 Make sure **jq** is installed—it's used to parse the download-URL JSON:
 ```bash
 sudo apt install -y jq

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ rm -rf ~/.config/Cursor ~/.cache/Cursor
 /opt/cursor.appimage --no-sandbox
 ```
 
+### **💡 "`jq: command not found` (or similar) during install?**
+Make sure **jq** is installed—it's used to parse the download-URL JSON:
+```bash
+sudo apt install -y jq
+```
+After installing, re-run `./install_cursor.sh`.
+
+
+
 ---
 
 ## 📜 License  

--- a/install_cursor.sh
+++ b/install_cursor.sh
@@ -3,7 +3,9 @@
 # Cursor Installation Script for Ubuntu 24.04
 # Author: Abdul's Setup Script
 
-CURSOR_URL="https://downloader.cursor.sh/linux/appImage/x64"
+CURSOR_URL="$(curl -fsSL \
+  'https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable' \
+  | jq -r '.downloadUrl')"
 CURSOR_APPIMAGE_PATH="$HOME/Downloads/Cursor.AppImage"
 APPIMAGE_DEST="/opt/cursor.appimage"
 ICON_URL="https://raw.githubusercontent.com/rahuljangirwork/copmany-logos/refs/heads/main/cursor.png"


### PR DESCRIPTION
The installer currently fails with curl: (6) Could not resolve host: downloader.cursor.sh because downloader.cursor.sh was de-provisioned in March 2025 and no longer points to the latest AppImage 

Forum posts:
[forum.cursor.com](https://forum.cursor.com/t/downloader-cursor-sh-linux-appimage-x64-no-longer-has-the-most-recent-app-image/63862?utm_source=chatgpt.com)
[forum.cursor.com](https://forum.cursor.com/t/downloader-cursor-sh-linux-appimage-x64-doesnt-give-the-latest-appimage/77514?utm_source=chatgpt.com)


This PR migrates the script to Cursor’s supported JSON download API (https://www.cursor.com/api/download) 